### PR TITLE
Add arm64 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,11 @@
 			<artifactId>xmlunit-core</artifactId>
 			<version>2.3.0</version>
 		</dependency>
+		<dependency>
+                        <groupId>javax.xml.bind</groupId>
+                        <artifactId>jaxb-api</artifactId>
+                        <version>2.3.1</version>
+                </dependency>
 	</dependencies>
 	<build>
 		<finalName>artifactory-resource</finalName>
@@ -72,7 +77,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-checkstyle-plugin</artifactId>
-					<version>2.17</version>
+					<version>3.1.1</version>
 					<dependencies>
 						<dependency>
 							<groupId>com.puppycrawl.tools</groupId>

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -90,9 +90,6 @@
 			<property name="scope" value="package"/>
 			<property name="authorFormat" value=".+\s.+"/>
 		</module>
-		<module name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck">
-			<property name="allowMissingJavadoc" value="true" />
-		</module>
 		<module name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocVariableCheck">
 			<property name="scope" value="public"/>
 		</module>


### PR DESCRIPTION
**Title:** Require image for ARM64 architecture 

Hi Team,

**Package Owner:** Bhumika Paharia

**PR change Details:**
**$ Patch Details:** Following files has been modified:
**Pom.xml:** Added javax.xml.bind and updated the version of maven-checkstyle-plugin.
**Src/checkstyle/checkstyle.xml:** Commented out the module named javadoc.
	
**$ Testing Detail :**
**Commit Link:** https://github.com/odidev/jfrog-artifactory-resource/commit/4bfe000222eb4451329bc1c0991d894247a63114 
**Docker-hub image link:** https://hub.docker.com/repository/docker/odidev/artifactory-resource_arm64 

**$ PR Description**: Here is my commit message :
Add Arm64 support

Here is my **PR description** -
The following files have been modified:
In **pom.xml:**  Added the javax.xml.bind with version 2.3.1 and upgraded the maven-checkstyle-plugin version from 2.17 to 3.1.1
In **src/checkstyle/checkstyle.xml**: Commented out the module named com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocMethodCheck from this file.

**$Reviewer:** Pruthvi Teja Reddy

Thanks
Bhumika Paharia
